### PR TITLE
New Resource: `databricks_dbfs_upload`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ ENHANCEMENTS:
 
 * **Provider:** Support for specifying the workspace organization ID ([#38](https://github.com/innovationnorway/terraform-provider-databricks/issues/38))
 
+* **New Resource:** `databricks_dbfs_upload` ([#33](https://github.com/innovationnorway/terraform-provider-databricks/issues/33))
+
 * **New Data Source:** `databricks_group_members` ([#27](https://github.com/innovationnorway/terraform-provider-databricks/issues/27))
 
 * **New Resource:** `databricks_group_member` ([#22](https://github.com/innovationnorway/terraform-provider-databricks/issues/22))

--- a/databricks/provider.go
+++ b/databricks/provider.go
@@ -87,6 +87,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"databricks_cluster":          resourceDatabricksCluster(),
 			"databricks_dbfs_mkdirs":      resourceDatabricksDbfsMkdirs(),
+			"databricks_dbfs_upload":      resourceDatabricksDbfsUpload(),
 			"databricks_group":            resourceDatabricksGroup(),
 			"databricks_group_member":     resourceDatabricksGroupMember(),
 			"databricks_workspace_import": resourceDatabricksWorkspaceImport(),

--- a/databricks/resource_databricks_dbfs_upload.go
+++ b/databricks/resource_databricks_dbfs_upload.go
@@ -1,0 +1,121 @@
+package databricks
+
+import (
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/innovationnorway/go-databricks/dbfs"
+)
+
+func resourceDatabricksDbfsUpload() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDatabricksDbfsUploadCreate,
+		Read:   resourceDatabricksDbfsUploadRead,
+		Update: resourceDatabricksDbfsUploadUpdate,
+		Delete: resourceDatabricksDbfsUploadDelete,
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"contents": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsBase64,
+			},
+		},
+	}
+}
+
+func resourceDatabricksDbfsUploadCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Meta).Dbfs
+	ctx := meta.(*Meta).StopContext
+
+	path := d.Get("path").(string)
+
+	attributes := dbfs.PutAttributes{
+		Path: &path,
+	}
+
+	if v, ok := d.GetOk("contents"); ok {
+		attributes.Contents = to.StringPtr(v.(string))
+	}
+
+	_, err := client.Put(ctx, attributes)
+	if err != nil {
+		return fmt.Errorf("unable to upload file: %s", err)
+	}
+
+	d.SetId(path)
+
+	return resourceDatabricksDbfsUploadRead(d, meta)
+}
+
+func resourceDatabricksDbfsUploadRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Meta).Dbfs
+	ctx := meta.(*Meta).StopContext
+
+	path := d.Get("path").(string)
+
+	resp, err := client.GetStatus(ctx, path)
+	if err != nil {
+		if resp.IsHTTPStatus(404) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("unable to get file status: %s", err)
+	}
+
+	d.Set("path", resp.Path)
+
+	return nil
+}
+
+func resourceDatabricksDbfsUploadUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Meta).Dbfs
+	ctx := meta.(*Meta).StopContext
+
+	path := d.Get("path").(string)
+
+	attributes := dbfs.PutAttributes{
+		Path:      &path,
+		Overwrite: to.BoolPtr(true),
+	}
+
+	if v, ok := d.GetOk("contents"); ok {
+		attributes.Contents = to.StringPtr(v.(string))
+	}
+
+	_, err := client.Put(ctx, attributes)
+	if err != nil {
+		return fmt.Errorf("unable to upload file: %s", err)
+	}
+
+	return resourceDatabricksDbfsUploadRead(d, meta)
+}
+
+func resourceDatabricksDbfsUploadDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Meta).Dbfs
+	ctx := meta.(*Meta).StopContext
+
+	path := d.Get("path").(string)
+
+	attributes := dbfs.DeleteAttributes{
+		Path: &path,
+	}
+
+	_, err := client.Delete(ctx, attributes)
+	if err != nil {
+		return fmt.Errorf("unable to delete file: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/databricks/resource_databricks_dbfs_upload_test.go
+++ b/databricks/resource_databricks_dbfs_upload_test.go
@@ -1,0 +1,59 @@
+package databricks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDatabricksDbfsUpload_basic(t *testing.T) {
+	resourceName := "databricks_dbfs_upload.test"
+	path := fmt.Sprintf("/mnt/foo/bar.txt")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabricksDbfsUploadDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabricksDbfsUploadBasic(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabricksDbfsUploadDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "databricks_dbfs_upload" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*Meta).Dbfs
+		ctx := testAccProvider.Meta().(*Meta).StopContext
+		resp, err := client.GetStatus(ctx, rs.Primary.ID)
+		if err != nil {
+			if resp.IsHTTPStatus(404) {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("DBFS file still exists:\n%#v", resp)
+	}
+
+	return nil
+}
+
+func testAccDatabricksDbfsUploadBasic(path string) string {
+	return fmt.Sprintf(`
+resource "databricks_dbfs_upload" "test" {
+  path     = "%s"
+  contents = base64encode("print(\"Hello, world!\")")
+}
+`, path)
+}

--- a/databricks/resource_databricks_dbfs_upload_test.go
+++ b/databricks/resource_databricks_dbfs_upload_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccDatabricksDbfsUpload_basic(t *testing.T) {
 	resourceName := "databricks_dbfs_upload.test"
-	path := fmt.Sprintf("/mnt/foo/bar.txt")
+	path := "/mnt/foo/bar.txt"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/website/databricks.erb
+++ b/website/databricks.erb
@@ -34,6 +34,10 @@
             <a href="/docs/providers/databricks/r/databricks_dbfs_mkdirs.html">databricks_dbfs_mkdirs</a>
           </li>
 
+          <li<%= sidebar_current("docs-databricks-resource-dbfs-upload") %>>
+            <a href="/docs/providers/databricks/r/databricks_dbfs_upload.html">databricks_dbfs_upload</a>
+          </li>
+
           <li<%= sidebar_current("docs-databricks-resource-group") %>>
             <a href="/docs/providers/databricks/r/databricks_group.html">databricks_group</a>
           </li>

--- a/website/docs/r/databricks_dbfs_upload.html.markdown
+++ b/website/docs/r/databricks_dbfs_upload.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "databricks"
+page_title: "Databricks: databricks_dbfs_upload"
+sidebar_current: "docs-databricks-resource-dbfs-upload"
+description: |-
+  Upload a file.
+---
+
+# databricks_dbfs_upload
+
+Upload a file.
+
+## Example Usage
+
+```hcl
+resource "databricks_dbfs_upload" "example" {
+  path     = "/mnt/foo/bar.txt"
+  contents = filebase64("bar.txt")
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `path` - (Required) The path of the new file. The path should be the absolute DBFS path (e.g. `/mnt/foo/bar.txt`).
+
+* `contents` - (Required) The base64-encoded content. This currently has a limit of 1 MB.
+
+-> **NOTE:** The amount of data that can be passed using `contents` parameter is currently limited to 1 MB; `MAX_BLOCK_SIZE_EXCEEDED` is thrown if exceeded. Using streaming upload to support large files will be added in a future release.


### PR DESCRIPTION
This pull request adds new resource `databricks_dbfs_upload`.

**Note 1:** The amount of data that can be passed using `contents` parameter is currently limited to 1 MB; `MAX_BLOCK_SIZE_EXCEEDED` is thrown if exceeded. Using streaming upload to support large files will be added in a future release.

**Note 2:** To reduce the size of the resource state, we will need to ensure we don't store the file `contents` in state once we release `v0.1.0` version. This will be fixed in a separate pull request (together with large file support).

Reference to #33