### PR TITLE
Fixing Docker Image Typo

### DIFF
--- a/databricks/data_source_databricks_cluster.go
+++ b/databricks/data_source_databricks_cluster.go
@@ -374,7 +374,7 @@ func dataSourceDatabricksCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"url": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -310,7 +310,7 @@ func resourceDatabricksCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"url": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Required: true,
 						},
 


### PR DESCRIPTION
The URL field of the Docker image must be a String according to the Databricks API
https://docs.databricks.com/dev-tools/api/latest/clusters.html#dockerimage