### PR TITLE
Add simple test cases, docs and address review comments for secrets resources

### DIFF
--- a/databricks/resource_databricks_secret_acl.go
+++ b/databricks/resource_databricks_secret_acl.go
@@ -24,27 +24,19 @@ func resourceDatabricksSecretAcl() *schema.Resource {
 			},
 			"principal": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"permission": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-
-					switch v {
-					case
-						"READ",
-						"WRITE",
-						"MANAGE":
-						return
-					}
-					errs = append(errs, fmt.Errorf("%q must be one of READ,WRITE or MANAGE. Got : %s", key, v))
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					string(secrets.READ),
+					string(secrets.WRITE),
+					string(secrets.MANAGE),
+				}, false),
 			},
 		},
 	}

--- a/databricks/resource_databricks_secret_acl_test.go
+++ b/databricks/resource_databricks_secret_acl_test.go
@@ -1,0 +1,77 @@
+package databricks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/innovationnorway/go-databricks/secrets"
+)
+
+func TestAccDatabricksSecretACL_basic(t *testing.T) {
+	resourceName := "databricks_secret_acl.test"
+	scope := acctest.RandString(6)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabricksSecretACLDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabricksSecretACLConfig(scope),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scope", scope),
+					resource.TestCheckResourceAttr(resourceName, "principal", "admins"),
+					resource.TestCheckResourceAttr(resourceName, "permission", "MANAGE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabricksSecretACLDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "databricks_secret_acl" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*Meta).Secrets
+		ctx := testAccProvider.Meta().(*Meta).StopContext
+
+		scope := rs.Primary.Attributes["scope"]
+		principal := rs.Primary.Attributes["principal"]
+
+		attributes := secrets.AclsAttributes{
+			Scope:     &scope,
+			Principal: &principal,
+		}
+
+		resp, err := client.GetAcls(ctx, attributes)
+		if err != nil {
+			if resp.IsHTTPStatus(404) {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Secret ACL still exists:\n%#v", resp)
+	}
+
+	return nil
+}
+
+func testAccDatabricksSecretACLConfig(scope string) string {
+	return fmt.Sprintf(`
+resource "databricks_secret_scope" "test" {
+  scope = "%s"
+}
+	
+resource "databricks_secret_acl" "test" {
+  scope      = databricks_secret_scope.test.scope
+  principal  = "admins"
+  permission = "MANAGE"
+}
+`, scope)
+}

--- a/databricks/resource_databricks_secret_scope.go
+++ b/databricks/resource_databricks_secret_scope.go
@@ -91,7 +91,7 @@ func resourceDatabricksSecretScopeDelete(d *schema.ResourceData, meta interface{
 
 	_, err := client.DeleteScope(ctx, attributes)
 	if err != nil {
-		return fmt.Errorf("unable to remove member: %s", err)
+		return fmt.Errorf("unable to delete scope: %s", err)
 	}
 
 	d.SetId("")
@@ -104,11 +104,7 @@ func isExistingScope(scope string, scopes *[]secrets.ScopeAttributes) bool {
 		return false
 	}
 
-	print("DEBUG SCOPES")
-	print(scopes)
-
 	for _, item := range *scopes {
-		print(*item.Name)
 		if scope == *item.Name {
 			return true
 		}

--- a/databricks/resource_databricks_secret_scope_test.go
+++ b/databricks/resource_databricks_secret_scope_test.go
@@ -1,0 +1,65 @@
+package databricks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDatabricksSecretScope_basic(t *testing.T) {
+	resourceName := "databricks_secret_scope.test"
+	scope := acctest.RandString(6)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabricksSecretScopeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabricksSecretScopeConfig(scope),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scope", scope),
+					resource.TestCheckResourceAttr(resourceName, "initial_manage_principal", "users"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabricksSecretScopeDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "databricks_secret_scope" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*Meta).Secrets
+		ctx := testAccProvider.Meta().(*Meta).StopContext
+
+		scope := rs.Primary.Attributes["scope"]
+
+		resp, err := client.ListScopes(ctx)
+		if err != nil {
+			return err
+		}
+
+		if !isExistingScope(scope, resp.Scopes) {
+			return nil
+		}
+
+		return fmt.Errorf("Secret scope still exists:\n%#v", resp)
+	}
+
+	return nil
+}
+
+func testAccDatabricksSecretScopeConfig(scope string) string {
+	return fmt.Sprintf(`
+resource "databricks_secret_scope" "test" {
+  scope                    = "%s"
+  initial_manage_principal = "users"
+}
+`, scope)
+}

--- a/databricks/resource_databricks_secret_test.go
+++ b/databricks/resource_databricks_secret_test.go
@@ -1,0 +1,77 @@
+package databricks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/innovationnorway/go-databricks/secrets"
+)
+
+func TestAccDatabricksSecret_basic(t *testing.T) {
+	resourceName := "databricks_secret.test"
+	scope := acctest.RandString(6)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabricksSecretDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabricksSecretConfig(scope),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scope", scope),
+					resource.TestCheckResourceAttr(resourceName, "key", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "string_value", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabricksSecretDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "databricks_secret" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*Meta).Secrets
+		ctx := testAccProvider.Meta().(*Meta).StopContext
+
+		scope := rs.Primary.Attributes["scope"]
+		key := rs.Primary.Attributes["key"]
+
+		attributes := secrets.ListSecretsAttributes{
+			Scope: &scope,
+		}
+
+		resp, err := client.List(ctx, attributes)
+		if err != nil {
+			if resp.IsHTTPStatus(404) || !isExistingSecret(key, resp.SecretsProperty) {
+				return nil
+			}
+
+			return err
+		}
+
+		return fmt.Errorf("Secret still exists:\n%#v", resp)
+	}
+
+	return nil
+}
+
+func testAccDatabricksSecretConfig(scope string) string {
+	return fmt.Sprintf(`
+resource "databricks_secret_scope" "test" {
+  scope = "%s"
+}
+
+resource "databricks_secret" "test" {
+  scope        = databricks_secret_scope.test.scope
+  key          = "foo"
+  string_value = "bar"
+}
+`, scope)
+}

--- a/website/databricks.erb
+++ b/website/databricks.erb
@@ -46,6 +46,18 @@
             <a href="/docs/providers/databricks/r/databricks_group_member.html">databricks_group_member</a>
           </li>
 
+          <li<%= sidebar_current("docs-databricks-resource-secret") %>>
+            <a href="/docs/providers/databricks/r/databricks_secret.html">databricks_secret</a>
+          </li>
+
+          <li<%= sidebar_current("docs-databricks-resource-secret-acl") %>>
+            <a href="/docs/providers/databricks/r/databricks_secret_acl.html">databricks_secret_acl</a>
+          </li>
+
+          <li<%= sidebar_current("docs-databricks-resource-secret-scope") %>>
+            <a href="/docs/providers/databricks/r/databricks_secret_scope.html">databricks_secret_scope</a>
+          </li>
+
           <li<%= sidebar_current("docs-databricks-resource-workspace-import") %>>
             <a href="/docs/providers/databricks/r/databricks_workspace_import.html">databricks_workspace_import</a>
           </li>

--- a/website/docs/r/databricks_secret.html.markdown
+++ b/website/docs/r/databricks_secret.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "databricks"
+page_title: "Databricks: databricks_secret"
+sidebar_current: "docs-databricks-resource-secret"
+description: |-
+  Create a new secret.
+---
+
+# databricks_secret
+
+Create a secret under the provided scope with the given name. If a secret already exists with the same name, this overwrites the existing secret's value.
+
+## Example Usage
+
+```hcl
+resource "databricks_secret_scope" "example" {
+  scope = "example"
+}
+
+resource "databricks_secret" "example" {
+  scope        = databricks_secret_scope.example.scope
+  key          = "foo"
+  string_value = "bar"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `scope` - (Required) The name of the scope to which the secret will be associated with.
+
+* `key` - (Required) A unique name to identify the secret.
+
+* `string_value` - (Optional) The value of the secret stored in UTF-8 (MB4) form.
+
+* `bytes_value` - (Optional) The value of the secret stored as bytes.
+
+-> **NOTE:** Either a `string_value` or `bytes_value` must be specified - but not both.

--- a/website/docs/r/databricks_secret_acl.html.markdown
+++ b/website/docs/r/databricks_secret_acl.html.markdown
@@ -33,7 +33,3 @@ The following arguments are supported:
 * `principal` - (Required) The principal to which the permission is applied.
 
 * `permission` - (Optional) The permission level applied to the principal. Possible values are: `READ`, `WRITE` and `MANAGE`.
-
-* `bytes_value` - (Optional) The value of the secret stored as bytes.
-
--> **NOTE:** Either `string_value` or `bytes_value` must be specified - but not both.

--- a/website/docs/r/databricks_secret_acl.html.markdown
+++ b/website/docs/r/databricks_secret_acl.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "databricks"
+page_title: "Databricks: databricks_secret_acl"
+sidebar_current: "docs-databricks-resource-secret-acl"
+description: |-
+  Create or overwrite the ACL associated with the given principal.
+---
+
+# databricks_secret_acl
+
+Create or overwrite the ACL associated with the given principal (user or group) on the specified scope point.
+
+## Example Usage
+
+```hcl
+resource "databricks_secret_scope" "example" {
+  scope = "example"
+}
+	
+resource "databricks_secret_acl" "example" {
+  scope      = databricks_secret_scope.example.scope
+  principal  = "data-scientists"
+  permission = "READ"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `scope` - (Required) The name of the scope to apply permissions to.
+
+* `principal` - (Required) The principal to which the permission is applied.
+
+* `permission` - (Optional) The permission level applied to the principal. Possible values are: `READ`, `WRITE` and `MANAGE`.
+
+* `bytes_value` - (Optional) The value of the secret stored as bytes.
+
+-> **NOTE:** Either `string_value` or `bytes_value` must be specified - but not both.

--- a/website/docs/r/databricks_secret_scope.html.markdown
+++ b/website/docs/r/databricks_secret_scope.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "databricks"
+page_title: "Databricks: databricks_secret_scope"
+sidebar_current: "docs-databricks-resource-secret-scope"
+description: |-
+  Create a secret scope.
+---
+
+# databricks_secret_scope
+
+Create a [Databricks-backed](https://docs.databricks.com/dev-tools/api/latest/secrets.html#secretscopebackendtype) secret scope in which secrets are stored in Databricks-managed storage and encrypted with a cloud-based specific encryption key.
+
+## Example Usage
+
+```hcl
+resource "databricks_secret_scope" "example" {
+  scope = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `scope` - (Required) Scope name requested by the user. Scope names are unique.
+
+* `initial_manage_principal` - (Optional) The principal that is initially granted `MANAGE` permission to the created scope.
+
+-> **NOTE:** If `initial_manage_principal` is specified, the initial ACL applied to the scope is applied to the supplied principal (user or group) with `MANAGE` permissions. The only supported principal for this option is the group `users`, which contains all users in the workspace. If `initial_manage_principal` is not specified, the initial ACL with `MANAGE` permission applied to the scope is assigned to the API request issuer's user identity.


### PR DESCRIPTION
* Adds documentation for `databricks_secret`, `databricks_secret_acl` and `databricks_secret_scope` resources
* Adds simple test cases for `databricks_secret`, `databricks_secret_acl` and `databricks_secret_scope` resources
* Addresses review comments in #58

```
go test -v ./... -run=TestAccDatabricksSecret
?       github.com/innovationnorway/terraform-provider-databricks       [no test files]
=== RUN   TestAccDatabricksSecretACL_basic
--- PASS: TestAccDatabricksSecretACL_basic (5.13s)
=== RUN   TestAccDatabricksSecretScope_basic
--- PASS: TestAccDatabricksSecretScope_basic (1.48s)
=== RUN   TestAccDatabricksSecret_basic
--- PASS: TestAccDatabricksSecret_basic (3.08s)
PASS
ok      github.com/innovationnorway/terraform-provider-databricks/databricks    9.812s
?       github.com/innovationnorway/terraform-provider-databricks/version       [no test files]
```

Reference to #58, #59