### PR TITLE
Add simple test case for creating cluster with custom Docker image

### DIFF
--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -30,6 +30,26 @@ func TestAccDatabricksCluster_AutoScale(t *testing.T) {
 	})
 }
 
+func TestAccDatabricksCluster_DockerImage(t *testing.T) {
+	resourceName := "databricks_cluster.test"
+	clusterName := acctest.RandString(6)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabricksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabricksClusterDockerImage(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", clusterName),
+					resource.TestCheckResourceAttr(resourceName, "docker_image.0.url", "databricksruntime/python:latest"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatabricksCluster_NumWorkers(t *testing.T) {
 	resourceName := "databricks_cluster.test"
 	clusterName := acctest.RandString(6)
@@ -127,6 +147,27 @@ resource "databricks_cluster" "test" {
   autoscale {
     min_workers = 2
     max_workers = 8
+  }
+
+  autotermination_minutes = 120
+}
+`, clusterName)
+}
+
+func testAccDatabricksClusterDockerImage(clusterName string) string {
+	return fmt.Sprintf(`
+resource "databricks_cluster" "test" {
+  cluster_name  = "%s"
+  spark_version = "6.3.x-scala2.11"
+  node_type_id  = "Standard_DS3_v2"
+
+  autoscale {
+    min_workers = 2
+    max_workers = 8
+  }
+
+  docker_image {
+	url = "databricksruntime/python:latest"
   }
 
   autotermination_minutes = 120


### PR DESCRIPTION
Reference to #60

```
go test -v ./... -run=TestAccDatabricksCluster_DockerImage
?       github.com/innovationnorway/terraform-provider-databricks       [no test files]
=== RUN   TestAccDatabricksCluster_DockerImage
--- PASS: TestAccDatabricksCluster_DockerImage (4.95s)
PASS
ok      github.com/innovationnorway/terraform-provider-databricks/databricks    7.660s
?       github.com/innovationnorway/terraform-provider-databricks/version       [no test files]
```